### PR TITLE
feat: allow any type of filter to be used

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import FilterContainer from './components/FilterContainer.vue'
+import CheckboxFilter from './components/CheckboxFilter.vue'
+import StringFilter from './components/StringFilter.vue'
 
 export default Vue.extend({
   name: 'App',
@@ -38,54 +40,54 @@ export default Vue.extend({
         description: 'search by name',
         initiallyCollapsed: true,
         placeholder: 'test',
-        type: 'string'
+        type: StringFilter
       }, {
         name: 'smoking',
         label: 'Smoking',
         initiallyCollapsed: false,
         options: [{ value: true, text: 'Yes' }, { value: false, text: 'No' }, { value: null, text: 'N/A' }],
-        type: 'checkbox'
+        type: CheckboxFilter
       }, {
         name: 'materials',
         label: 'Materials',
         initiallyCollapsed: false,
         options: [],
         maxVisibleOptions: 4,
-        type: 'checkbox'
+        type: CheckboxFilter
       }, {
         name: 'country',
         label: 'Countries',
         initiallyCollapsed: false,
         options: [{ value: 'value', text: 'label' }, { value: 'nl', text: 'Nederland' }, { value: 'de', text: 'Duitseland' }],
-        type: 'checkbox'
+        type: CheckboxFilter
       }, {
         name: 'biobank_quality',
         label: 'Biobank quality marks',
         initiallyCollapsed: false,
         options: [],
         maxVisibleOptions: 4,
-        type: 'checkbox'
+        type: CheckboxFilter
       }, {
         name: 'collection_quality',
         label: 'Collection quality marks',
         initiallyCollapsed: false,
         options: [],
         maxVisibleOptions: 4,
-        type: 'checkbox'
+        type: CheckboxFilter
       }, {
         name: 'type',
         label: 'Collection Types',
         initiallyCollapsed: false,
         options: [],
         maxVisibleOptions: 4,
-        type: 'checkbox'
+        type: CheckboxFilter
       }, {
         name: 'dataType',
         label: 'Data types',
         initiallyCollapsed: false,
         options: [],
         maxVisibleOptions: 4,
-        type: 'checkbox'
+        type: CheckboxFilter
       }]
     }
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,9 +19,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import FilterContainer from './components/FilterContainer.vue'
-import CheckboxFilter from './components/CheckboxFilter.vue'
-import StringFilter from './components/StringFilter.vue'
+import { FilterContainer, StringFilter, CheckboxFilter } from './components'
 
 export default Vue.extend({
   name: 'App',

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,13 +19,11 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { FilterContainer, StringFilter, CheckboxFilter } from './components'
+import * as components from './components'
 
 export default Vue.extend({
   name: 'App',
-  components: {
-    FilterContainer
-  },
+  components,
   data () {
     return {
       selections: {
@@ -38,54 +36,54 @@ export default Vue.extend({
         description: 'search by name',
         initiallyCollapsed: true,
         placeholder: 'test',
-        type: StringFilter
+        type: 'string-filter'
       }, {
         name: 'smoking',
         label: 'Smoking',
         initiallyCollapsed: false,
         options: [{ value: true, text: 'Yes' }, { value: false, text: 'No' }, { value: null, text: 'N/A' }],
-        type: CheckboxFilter
+        type: 'checkbox-filter'
       }, {
         name: 'materials',
         label: 'Materials',
         initiallyCollapsed: false,
         options: [],
         maxVisibleOptions: 4,
-        type: CheckboxFilter
+        type: 'checkbox-filter'
       }, {
         name: 'country',
         label: 'Countries',
         initiallyCollapsed: false,
         options: [{ value: 'value', text: 'label' }, { value: 'nl', text: 'Nederland' }, { value: 'de', text: 'Duitseland' }],
-        type: CheckboxFilter
+        type: 'checkbox-filter'
       }, {
         name: 'biobank_quality',
         label: 'Biobank quality marks',
         initiallyCollapsed: false,
         options: [],
         maxVisibleOptions: 4,
-        type: CheckboxFilter
+        type: 'checkbox-filter'
       }, {
         name: 'collection_quality',
         label: 'Collection quality marks',
         initiallyCollapsed: false,
         options: [],
         maxVisibleOptions: 4,
-        type: CheckboxFilter
+        type: 'checkbox-filter'
       }, {
         name: 'type',
         label: 'Collection Types',
         initiallyCollapsed: false,
         options: [],
         maxVisibleOptions: 4,
-        type: CheckboxFilter
+        type: 'checkbox-filter'
       }, {
         name: 'dataType',
         label: 'Data types',
         initiallyCollapsed: false,
         options: [],
         maxVisibleOptions: 4,
-        type: CheckboxFilter
+        type: 'checkbox-filter'
       }]
     }
   }

--- a/src/components/FilterContainer.vue
+++ b/src/components/FilterContainer.vue
@@ -5,15 +5,9 @@
       :key="filter.name"
       v-bind="filter"
     >
-      <string-filter
-        v-if="filter.type === 'string'"
+      <component
+        :is="filter.type"
         :name="name"
-        :value="value[filter.name]"
-        v-bind="filter"
-        @input="(value) => selectionChange(filter.name, value)"
-      />
-      <checkbox-filter
-        v-if="filter.type === 'checkbox'"
         :value="value[filter.name]"
         v-bind="filter"
         @input="(value) => selectionChange(filter.name, value)"


### PR DESCRIPTION
The filter list can contain any type of filter component, it need not be specified in this library.
Use `<component :is="string-filter">` to set it.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Conventional commits (squash if needed)
- [x] No warnings during install
- [x] Updated javascript typing
