### PR TITLE
fix: Filter card item partial rendering

### DIFF
--- a/src/components/FilterCard.vue
+++ b/src/components/FilterCard.vue
@@ -8,7 +8,7 @@
       @click="toggleState"
     >
       <div
-        class="title mr-3"
+        class="title mr-3 px-1"
         :title="label"
       >
         <font-awesome-icon

--- a/tests/unit/components/__snapshots__/FilterCard.spec.ts.snap
+++ b/tests/unit/components/__snapshots__/FilterCard.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`FilterCard.vue matches the snapshot 1`] = `
     class="card-header collapsable"
   >
     <div
-      class="title mr-3"
+      class="title mr-3 px-1"
       title="label"
     >
       <svg

--- a/tests/unit/components/__snapshots__/FilterContainer.spec.ts.snap
+++ b/tests/unit/components/__snapshots__/FilterContainer.spec.ts.snap
@@ -19,7 +19,7 @@ exports[`FilterContainer.vue matches the snapshot 1`] = `
           class="card-header"
         >
           <div
-            class="title mr-3"
+            class="title mr-3 px-1"
             title="String"
           >
             <!---->
@@ -109,7 +109,7 @@ exports[`FilterContainer.vue matches the snapshot 1`] = `
           class="card-header collapsable"
         >
           <div
-            class="title mr-3"
+            class="title mr-3 px-1"
             title="Checkbox"
           >
             <div


### PR DESCRIPTION
Icons was partially obscured in a overflow: hidden box.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing