### PR TITLE
fix: #16 remove vue-bootstrap warning from test output

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@
 // with an external tool like vscode-jest.
 process.env.VUE_CLI_BABEL_TARGET_NODE = true
 process.env.VUE_CLI_BABEL_TRANSPILE_MODULES = true
+process.env.BOOTSTRAP_VUE_NO_WARN = true
 process.env.TZ = 'GMT'
 
 module.exports = {


### PR DESCRIPTION
Warning does not effect test as test is not run in browser enviroment

Closes: #16

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Conventional commits (squash if needed)
- [ ] No warnings during install
- [ ] Updated javascript typing
